### PR TITLE
Fix: Correct script comments to reference Claude Desktop (#17)

### DIFF
--- a/scripts/damien-work-start.sh
+++ b/scripts/damien-work-start.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+##############################################################################
+# Damien Work Session - Start
+#
+# This script:
+# 1. Starts all Damien services
+# 2. Enables MCP in Claude Code
+# 3. Automatically restarts Claude Desktop to load MCP tools
+# 4. Provides a resume prompt for the new session
+#
+# Note: This script restarts Claude Desktop (the native macOS app) rather than
+# Claude Code (the CLI tool) because Claude Desktop has built-in MCP server
+# support, making it ideal for testing the 48 Damien MCP tools.
+#
+# Usage: ./scripts/damien-work-start.sh
+##############################################################################
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "🚀 Starting Damien Work Session"
+echo "================================"
+echo ""
+
+# Step 1: Start services and enable MCP
+echo "📊 Step 1: Starting services and enabling MCP..."
+"$SCRIPT_DIR/start-all.sh"
+echo ""
+
+# Step 2: Generate resume prompt
+echo "📝 Step 2: Generating resume prompt..."
+RESUME_PROMPT="Test Damien MCP Integration - Session Start
+
+I'm ready to test all 48 Damien Email Wrestler tools with my real Gmail data.
+
+**Services Status**: All running and healthy
+**MCP Tools**: Freshly loaded and ready
+**Project**: /Users/ivanrivera/Downloads/AWS/DamienPlatform/damien-email-wrestler
+
+**First Test - Email Discovery:**
+Show me my 2 most recent unread emails with full content.
+
+Use:
+- damien_list_emails (query: 'is:unread', max_results: 2)
+- damien_get_email_details for each email ID
+
+This validates: Basic connectivity, parameter handling, Gmail API access."
+
+# Save to clipboard (macOS only)
+if command -v pbcopy &> /dev/null; then
+    echo "$RESUME_PROMPT" | pbcopy
+    echo "✅ Resume prompt copied to clipboard!"
+    echo ""
+fi
+
+echo "📋 Resume Prompt (also in clipboard):"
+echo "─────────────────────────────────────"
+echo "$RESUME_PROMPT"
+echo "─────────────────────────────────────"
+echo ""
+
+# Step 3: Restart Claude Desktop
+echo "🔄 Step 3: Restarting Claude Desktop..."
+echo ""
+echo "⚠️  Claude Desktop will now:"
+echo "   1. Quit (saving your current session)"
+echo "   2. Wait 3 seconds"
+echo "   3. Reopen with this project"
+echo ""
+echo "💡 After restart, paste the resume prompt to continue"
+echo ""
+read -p "Press ENTER to restart Claude Desktop now, or Ctrl+C to cancel..."
+
+# Quit Claude Desktop
+osascript -e 'quit app "Claude"' 2>/dev/null || true
+
+# Wait for clean shutdown
+echo "⏳ Waiting for clean shutdown..."
+sleep 3
+
+# Reopen Claude Desktop with this project
+echo "🎯 Reopening Claude Desktop..."
+open -a "Claude" "$PROJECT_ROOT"
+
+echo ""
+echo "✅ Damien Work Session Started!"
+echo ""
+echo "📋 Next Steps:"
+echo "   1. Wait for Claude Desktop to fully load"
+echo "   2. Start a new chat"
+echo "   3. Paste the resume prompt (already in clipboard)"
+echo "   4. Begin testing the 48 tools!"
+echo ""


### PR DESCRIPTION
## Description
This PR fixes misleading comments in the damien-work-start.sh script that incorrectly referenced 'Claude Code' when the script actually restarts 'Claude Desktop'.

## Related Issues
Fixes #17

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Changes Made
- Updated header comments to clarify Claude Desktop is restarted, not Claude Code
- Added explanatory note about why Claude Desktop is preferred (MCP server support)
- Fixed all user-facing messages to correctly reference Claude Desktop
- Updated final instructions to reference Claude Desktop

## Testing Performed

### Manual Testing
- [x] Reviewed script changes - only comments modified
- [x] Verified actual osascript/open commands unchanged (still correct)
- [x] Script syntax is valid (no logic changes)

### Automated Testing
- [x] No code logic changed - only comments/messages updated
- [x] Script remains executable

## Pre-Deployment Checklist
- [x] Code follows project style guidelines
- [x] Self-review of code performed
- [x] Comments updated (that's the whole point!)
- [x] Documentation updated
- [x] No service changes required

## Deployment Notes

### Configuration Changes
None - only comments changed

### Service Restart Required
- [ ] No service restart needed (documentation/comments only)

## Additional Notes
This is a simple documentation fix that resolves user confusion. The script's actual functionality is unchanged - it was always restarting Claude Desktop correctly, just with misleading comments.